### PR TITLE
Bump max version to 27

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,6 +13,6 @@
     <category>tools</category>
     <bugs>https://github.com/nextcloud/hmr_enabler</bugs>
     <dependencies>
-        <nextcloud min-version="22" max-version="26" />
+        <nextcloud min-version="22" max-version="27" />
     </dependencies>
 </info>


### PR DESCRIPTION
I am trying to run current nextcloud dev (27.0.0.dev) using [nextcloud-docker-dev](https://github.com/juliushaertl/nextcloud-docker-dev) and it fails with this error message:
> App "HMR Enabler" cannot be installed because it is not compatible with this version of the server.

Bumping the maximum version to 27 seems to fix the issue.