### PR TITLE
Bump max version to 30

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,6 +13,6 @@
     <category>tools</category>
     <bugs>https://github.com/nextcloud/hmr_enabler</bugs>
     <dependencies>
-        <nextcloud min-version="26" max-version="28" />
+        <nextcloud min-version="26" max-version="30" />
     </dependencies>
 </info>


### PR DESCRIPTION
Fix https://github.com/juliushaertl/nextcloud-docker-dev/issues/313

Since this is mostly a development tool I bumped to 30 already to be prepared for the branch off that happens soonish