### PR TITLE
fix(ocp): Fix compatibility with Nextcloud 34+

### DIFF
--- a/lib/Listener/LaxifyCSP.php
+++ b/lib/Listener/LaxifyCSP.php
@@ -17,12 +17,8 @@ class LaxifyCSP implements IEventListener {
 			return;
 		}
 
-		$csp = new ContentSecurityPolicy();
-
-		// Allow vue dev tool to work on Firefox.
-		$csp->allowEvalScript(true);
-
 		// Unblock HMR requests.
+		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedConnectDomain('*');
 		$csp->addAllowedScriptDomain('*');
 


### PR DESCRIPTION
- `allowEvalScript` was removed upstream
- It seems at least from a quick test that Firefox Vue Dev tools now work without it.